### PR TITLE
Improve extensability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,37 @@ function test_post_author_is_authorized()
 }
 ```
 
+## Extending
+
+If you need additional/custom assertions, you can easily extend the `\Jcergolj\FormRequestAssertions\TestFormRequest` class.
+
+In your project
+1. Create a new class, for example: `\Tests\Support\TestFormRequest` extending the `\Jcergolj\FormRequestAssertions\TestFormRequest` class.
+   ```php
+   namespace Tests\Support;
+   class TestFormRequest extends \Jcergolj\FormRequestAssertions\TestFormRequest
+   {
+     public function assertSomethingImportant()
+     {
+       // your assertions on `$this->request`
+     }
+   }
+   ```
+2. Create a new trait, for example: `\Tests\Traits\TestableFormRequest` using the `\Jcergolj\FormRequestAssertions\TestableFormRequest` trait.
+3. Overwrite the `\Jcergolj\FormRequestAssertions\TestableFormRequest::createNewTestFormRequest` method to return an instance of the class created in (1).
+   ```php
+   namespace Tests\Support;
+   trait TestableFormRequest {
+     use \Jcergolj\FormRequestAssertions\TestableFormRequest;
+   
+     protected function createNewTestFormRequest(FormRequest $request): TestFormRequest
+     {
+       return new \Tests\Support\TestFormRequest($request);
+     }
+   }
+   ```
+4. Use your custom trait instead of `\Jcergolj\FormRequestAssertions\TestableFormRequest` on your test classes
+
 # Available Methods
 
 ```php

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 class TestFormRequest
 {
-    private FormRequest $request;
+    protected FormRequest $request;
 
     public function __construct(FormRequest $request)
     {
@@ -86,7 +86,7 @@ class TestFormRequest
         );
     }
 
-    private function bully(\Closure $elevatedFunction, object $targetObject)
+    protected function bully(\Closure $elevatedFunction, object $targetObject)
     {
         return \Closure::fromCallable($elevatedFunction)->call($targetObject);
     }

--- a/src/TestValidationResult.php
+++ b/src/TestValidationResult.php
@@ -10,9 +10,9 @@ use PHPUnit\Framework\Assert;
 
 class TestValidationResult
 {
-    private Validator $validator;
+    protected Validator $validator;
 
-    private ?ValidationException $failed;
+    protected ?ValidationException $failed;
 
     public function __construct(Validator $validator, ?ValidationException $failed = null)
     {

--- a/src/TestableFormRequest.php
+++ b/src/TestableFormRequest.php
@@ -85,6 +85,11 @@ trait TestableFormRequest
         $route->parameters = [];
         $formRequest->setRouteResolver(fn () => $route);
 
-        return new TestFormRequest($formRequest);
+        return $this->createNewTestFormRequest($formRequest);
+    }
+
+    protected function createNewTestFormRequest(FormRequest $request): TestFormRequest
+    {
+        return new TestFormRequest($request);
     }
 }


### PR DESCRIPTION
I was in the need to extend the `Jcergolj\FormRequestAssertions\TestFormRequest` class to add my own assertions. This was hard and required a lot of copy and paste because of private methods and properties. Also replacing the `TestFormRequest` class with my on derivation required me to do something like this:

```php
<?php
namespace Tests\Traits;

use Jcergolj\FormRequestAssertions\TestableFormRequest;
use Tests\Support\TestFormRequest; // extends \Jcergolj\FormRequestAssertions\TestFormRequest

trait MyTestableFormRequest
{
    use TestableFormRequest {
        createFormRequest as traitCreateFormRequest;
    }

    protected function createFormRequest(string $requestClass, $headers = []): TestFormRequest
    {
        $testRequest = $this->traitCreateFormRequest($requestClass, $headers);

        $result = null;
        \Closure::fromCallable(function () use (&$result) {
            $result = new TestFormRequest($this->request);
        })
            ->call($testRequest);

        return  $result;
    }
}
```

This could now be shorted to the following just by overriding the newly introduced `createNewTestFormRequest`:

```php
<?php
namespace Tests\Traits;

use Jcergolj\FormRequestAssertions\TestableFormRequest;
use Tests\Support\TestFormRequest; // extends \Jcergolj\FormRequestAssertions\TestFormRequest

trait MyTestableFormRequest
{
    use TestableFormRequest;

    protected function createNewTestFormRequest(FormRequest $request): TestFormRequest
    {
        return new TestFormRequest($request);
    }
}
```
