### PR TITLE
Add 'calls gate' assertion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,14 @@ assertNotAuthorized()
 ```
 
 ```php
+/**
+ * example: assertCallsGate('create', User::class); 
+ * -> asserts that the `authorize` method of the request checks that `$user->can('create', User::class)` 
+ */
+assertCallsGate($action, $params)
+```
+
+```php
 assertPasses()
 ```
 

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -86,6 +86,18 @@ class TestFormRequest
         );
     }
 
+    public function assertCallsGate($action, $params): void
+    {
+        \Gate::expects('forUser')
+            ->andReturnSelf();
+        \Gate::shouldReceive('check')
+            ->once()
+            ->with($action, $params)
+            ->andReturn(true);
+
+        $this->bully(fn () => $this->passesAuthorization(), $this->request);
+    }
+
     private function bully(\Closure $elevatedFunction, object $targetObject)
     {
         return \Closure::fromCallable($elevatedFunction)->call($targetObject);

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class TestFormRequest
 {
     private FormRequest $request;
-    protected ?\Mockery\ClosureWrapper $userResolver = null;
+    protected null|\Closure|\Mockery\LegacyMockInterface $userResolver = null;
 
     public function __construct(FormRequest $request)
     {

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -97,11 +97,13 @@ class TestFormRequest
             ->once()
             ->with($action, $params)
             ->andReturn(true);
-        if ($guard && !$this->userResolver) {
-            $this->by(null);
+
+        if (!$this->userResolver) {
+            $this->by(new class extends \Illuminate\Foundation\Auth\User {});
         }
 
         $this->bully(fn () => $this->passesAuthorization(), $this->request);
+
         if ($guard) {
             $this->userResolver->shouldHaveBeenCalled()
                 ->with($guard);

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -5,6 +5,7 @@ namespace Jcergolj\FormRequestAssertions;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Auth\Access\Gate;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -88,9 +89,9 @@ class TestFormRequest
 
     public function assertCallsGate($action, $params): void
     {
-        \Gate::expects('forUser')
+        Gate::expects('forUser')
             ->andReturnSelf();
-        \Gate::shouldReceive('check')
+        Gate::shouldReceive('check')
             ->once()
             ->with($action, $params)
             ->andReturn(true);


### PR DESCRIPTION
When using dedicated tests for policies, its not useful to use the `assertAuthorized` and `assertNotAuthorized` assertions. Instead it would be better to test, that the request is calling the right gate (policy).

The PR adds a new assertion `assertCallsGate` for this use-case. The assertion takes two mandatory parameters, these assert the values passed to the `$user->can('ability', MyModel::class)` method. It also accepts an optional third parameter to define the gate that is expected to be used, wich is particularly useful in situations where you use multiple/custom gates.

**Example Request:**
```php
class CreateUserRequest extends FormRequest
{
    public function authorize(): bool
    {
        return $this->user('my-guard')->can('create', User::class);
    }
}
```

**Test:**

*The Test ensures that the request is checking the `UserPolicy::create` ability, regardless of the result. Implementation of that policy can be tested in a dedicated test.*

```php
class CreateUserRequestTest extends TestCase
{
    use TestsFormRequests;

    public function test_uses_create_user_gate(): void
    {
        $user = User::factory()->create();

        $this->createFormRequest(CreateRequest::class)
            ->actingAs($user)
            ->assertCallsGate('create', User::class, 'my-guard');
    }
}
```