### PR TITLE
Fix error when using invokable controller

### DIFF
--- a/src/TestableFormRequest.php
+++ b/src/TestableFormRequest.php
@@ -35,6 +35,10 @@ trait TestableFormRequest
         $controller = RouteFacade::getRoutes()->getByName(RouteFacade::currentRouteName())->getController();
         $method = RouteFacade::getRoutes()->getByName(RouteFacade::currentRouteName())->getActionMethod();
 
+        if ($method === $controller::class) {
+          $method = '__invoke';
+        }
+
         $reflectionMethod = new ReflectionMethod($controller, $method);
         $reflectionParams = collect($reflectionMethod->getParameters());
 


### PR DESCRIPTION
When using invokable controllers the `assertContainsFormRequest` assertion causes an error:

```
ReflectionException: Method App\Http\Controllers\Api\V1\Auth\Session\CreateController::App\Http\Controllers\Api\V1\Auth\Session\CreateController() does not exist
/var/www/html/vendor/jcergolj/laravel-form-request-assertions/src/TestableFormRequest.php:38
```

```php
<?php

namespace App\Http\Controllers\Api\V1\Auth\Session;

use App\Http\Controllers\Api\V1\Controller;
use App\Http\Requests\Api\V1\Auth\Session\CreateRequest;

class CreateController extends Controller
{
    public function __invoke(CreateRequest $request): \Illuminate\Http\JsonResponse
    {
      // snip...
    }
}
```

This is caused by `RouteFacade::getRoutes()->getByName(RouteFacade::currentRouteName())->getActionMethod()` - it returns the controller class name for invokable controllers, which seems like a Laravel bug in the first place. However further investigation led me to to the conclusion that this behavior is actually intended by Laravel/Illuminate.

**The PR introduces a small change: when controller class-name equals method-name it is assumed that its an invokable controller and `__invoke` is used as method-name instead.**