### PR TITLE
Prepare validation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,21 @@ function test_post_author_is_authorized()
 }
 ```
 
+### Test data preparation
+
+Test how data is prepared within the `prepareForValidation` method of the `FormRequest`.
+
+```php
+ /** @test */
+function test_transforms_email_to_lowercase_before_validation()
+{
+    $this->createFormRequest(CreatePostRequest::class)
+        ->onPreparedData(['email' => 'TeSt@ExAmPlE.cOm'], function (array $preparedData) {
+            $this->assertEquals('test@example.com', $preparedData['email']);
+        });
+}
+```
+
 ## Extending
 
 If you need additional/custom assertions, you can easily extend the `\Jcergolj\FormRequestAssertions\TestFormRequest` class.

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -29,7 +29,7 @@ class TestFormRequest
 
     public function validate(array $data)
     {
-        $validator = $this->validator($data);
+        $validator = $this->validator($this->prepareForValidation($data));
 
         try {
             $validator->validate();
@@ -89,5 +89,13 @@ class TestFormRequest
     protected function bully(\Closure $elevatedFunction, object $targetObject)
     {
         return \Closure::fromCallable($elevatedFunction)->call($targetObject);
+    }
+
+    protected function prepareForValidation(array $data): array
+    {
+        $this->request->replace($data);
+        $this->bully(fn () => $this->prepareForValidation(), $this->request);
+
+        return $this->request->all();
     }
 }

--- a/src/TestFormRequest.php
+++ b/src/TestFormRequest.php
@@ -86,6 +86,13 @@ class TestFormRequest
         );
     }
 
+    public function onPreparedData(array $data, callable $callback)
+    {
+        $callback($this->prepareForValidation($data));
+
+        return $this;
+    }
+
     protected function bully(\Closure $elevatedFunction, object $targetObject)
     {
         return \Closure::fromCallable($elevatedFunction)->call($targetObject);


### PR DESCRIPTION
This PR ensures the `prepareForValidation` is called on the data before passing it to the validator. It also adds the `onPreparedData`method, enabling the developer to test, how the request handles data preparation as shown in the example below.

```php
function test_transforms_email_to_lowercase_before_validation(): void
{
  $this->createFormRequest(CreatePostRequest::class)
    ->onPreparedData(['email' => 'TeSt@ExAmPlE.cOm'], function (array $preparedData) {
      $this->assertEquals('test@example.com', $preparedData['email']);
    });
}
```

This addresses #3 