### PR TITLE
Assertion for passed rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ public function controller_has_form_request()
 }
 ```
 
-### Test Validation Rules
+### Test failed Validation Rules
 
 ```php
 public function email_is_required()
@@ -124,6 +124,24 @@ public function email_is_required()
         ->assertFails(['password' => App\Rules\PasswordRule::class]); //custom password rule class
 }
 ```
+
+### Test passed validation rules
+
+In some situations you might not care weather the whole request validates but that a set of validation rules passes.
+
+```php
+public function test_email_is_not_required()
+{
+    /**
+     * Validation rules: ['email' => 'email|nullable']
+     */
+    $this->createFormRequest(CreatePostRequest::class)
+        ->validate([])
+        ->assertPassesRules(['email' => 'required']);
+}
+```
+
+**ALERT** this only checks that the rule didn't fail, it doesn't check that the rule was actually applied in the first place!
 
 ### Test Form Request
 

--- a/src/TestValidationResult.php
+++ b/src/TestValidationResult.php
@@ -118,4 +118,36 @@ class TestValidationResult
         Assert::assertArrayHasKey($expectedFailedRule, $failedRules);
         Assert::assertStringContainsString($constraints, $failedRules[$expectedFailedRule]);
     }
+
+    public function assertPassesRules($expectedPassedRules = []): static
+    {
+        if ($this->validator->passes()) {
+            Assert::assertTrue(true); // Prevent assertion-count is 0
+
+            return $this;
+        }
+
+        $failedRules = $this->getFailedRules();
+
+        foreach ($expectedPassedRules as $expectedPassedRule => $constraints) {
+            $this->assertPassedRule($constraints, $failedRules, $expectedPassedRule);
+        }
+
+        return $this;
+    }
+
+    protected function assertPassedRule($constraints, $failedRules, $expectedFailedRule): void
+    {
+        if (class_exists($constraints)) {
+            Assert::assertNotContains(strtolower($constraints), $failedRules);
+
+            return;
+        }
+
+        if ($failedRules->has($expectedFailedRule)) {
+            Assert::assertStringNotContainsString($constraints, $failedRules[$expectedFailedRule]);
+        } else {
+            Assert::assertTrue(true); // Prevent assertion-count is 0
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new assertion to check for rules that didn't fail.

In my use-case i generate a ruleset in a common base-class shared by `post` and `patch` form-request classes. I need to ensure, properties are not `required` in the `patch` request.

```php
public function test_email_is_not_required()
{
    $this->createFormRequest(CreatePostRequest::class)
        ->validate([])
        ->assertPassesRules(['email' => 'required']);
}
``` 

Though the assertion-name can suggest something different, this assertion only checks that the named rule doesn't appear in failures. It doesn't check weather the rule has actually been evaluated - this is intentional. However I was not able to come up with a better name - suggestions welcome.